### PR TITLE
Add handling for messages longer than 160 and for MMS

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -71,7 +71,7 @@ export class App {
 			return;
         }
         
-        await p.client.sendSMS(room.roomId, data.body);
+        await p.client.sendMessage(room.roomId, data.body);
     }
 
     public async handleSMSMessage(puppetId: number, data: IVoipMSSms) {

--- a/src/voipms.ts
+++ b/src/voipms.ts
@@ -35,7 +35,7 @@ export class Client extends EventEmitter {
   smsCheckInterval?: any;
 
   public start() {
-    // to accont for timing issues we run every 30 seconds, and check the past 35 seconds of messages
+    // to account for timing issues we run every 30 seconds, and check the past 35 seconds of messages
     // we then keep a single checks worth of cache so that we do not duplicate sending messages
     let lastRun: string[] = []
     this.smsCheckInterval = setInterval(async () => {
@@ -59,7 +59,7 @@ export class Client extends EventEmitter {
     }
   }
 
-  async sendSMS(dst: string, message: string) {
+  async sendMessage(dst: string, message: string) {
     let _method = getMethod(message);
     log.verbose(`Sending message "${message}" to ${dst} via ${_method}`);
 
@@ -76,26 +76,6 @@ export class Client extends EventEmitter {
   }
 
   // See this issue for timezone explanation https://github.com/michaelkourlas/voipms-sms-client/issues/35
-  async getSMS(type: SmsType, from: moment.Moment): Promise<IVoipMSSms[]> {
-    const r = await get(API_URL, {
-      params: {
-        api_username: this.data.user,
-        api_password: this.data.api_password,
-        method: 'getSMS',
-        type: type,
-        did: this.data.did,
-        from: from.tz('America/New_York').format('YYYY-MM-DD HH:mm:ss'),
-        timezone: -5
-      }
-    })
-
-    if (r.data.status !== 'success') {
-      return []
-    }
-
-    return r.data.sms
-  }
-
   async getMessages(type: SmsType, from: moment.Moment): Promise<IVoipMSSms[]> {
     const r = await get(API_URL, {
       params: {

--- a/src/voipms.ts
+++ b/src/voipms.ts
@@ -63,12 +63,14 @@ export class Client extends EventEmitter {
   }
 
   async sendSMS(dst: string, message: string) {
-    log.verbose(`Sending message "${message}" to ${dst}`)
+	let _method = getMethod(message);
+    log.verbose(`Sending message "${message}" to ${dst} via ${_method}`);
+
     return await get(API_URL, {
       params: {
         api_username: this.data.user,
         api_password: this.data.api_password,
-        method: 'sendSMS',
+        method: _method,
         did: this.data.did,
         dst,
         message
@@ -121,4 +123,14 @@ export class Client extends EventEmitter {
 export function validatePhoneNumber(number: string): boolean {
   const validator = /^[0-9]{10}$/;
   return number.match(validator) !== null;
+}
+
+function getMethod(message: string) {
+	let method = 'sendSMS'
+	const emojiRegex = /\p{Emoji}/u;
+	if (message.length >= 160 || emojiRegex.test(message)) {
+		method = 'sendMMS'
+	}
+
+	return method;
 }


### PR DESCRIPTION
Closes #4 

I changed the `sendSMS` function so that if the message is longer than 160 characters, or if it contains an emoji, it uses the `sendMMS` API call instead, so the messages are sent correctly. The issue #4 proposed to cut the message in multiple SMSes of 160 characters or less, but I think it's better to send an MMS rather than multiple SMSes? I think most devices today are capable of handling MMSes.

I also replaced the `getSMS` and `getMMS` functions with `getMessages`, which is essentially `getMMS `, with the added `all_messages: 1` argument, which tells voip.ms to send us all messages, MMS _or_ SMS.

Additionally, I increased the fetch history to 1 minute, since the bridge dropped messages sometimes in my tests. Increasing it to 1 minute solved that. Since the code already checks for the message ID to ignore duplicates, I felt it was fine to increase it to a minute.